### PR TITLE
Update QFileFormStateHandler.class.php

### DIFF
--- a/includes/qcodo/_core/qform_state_handlers/QFileFormStateHandler.class.php
+++ b/includes/qcodo/_core/qform_state_handlers/QFileFormStateHandler.class.php
@@ -20,7 +20,7 @@
 		 *
 		 * @var string StatePath
 		 */
-		public static $StatePath = '/tmp';
+		public static $StatePath = __TRACMOR_TMP__;
 
 		/**
 		 * The filename prefix to be used by all FormState files


### PR DESCRIPTION
Removed recursive '\tmp' with the variable **TRACMOR_TMP** that is defined in configuration.inc.php. This fixes the PHP error when attempting to log out on an IIS machine (and possibly others).
